### PR TITLE
Chore: Remove mythx vscode plugin

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,6 @@
         }
       },
       "extensions": [
-        "MythX.mythxvsc",
         "joaompinto.vscode-graphviz",
         "cschleiden.vscode-github-actions",
         "GitHub.vscode-pull-request-github",


### PR DESCRIPTION
- Removing this plugin because it clashes with hardhat plugin from nomic
  foundation.
